### PR TITLE
Remove the outdated information on the tespy Bus usage

### DIFF
--- a/docs/examples/ccpp.rst
+++ b/docs/examples/ccpp.rst
@@ -176,32 +176,9 @@ The import of the exerpy dependency is the same for all simulators:
         inputs to the combustion process. The exhaust stream (:code:`8`) and
         the difference between the exergy values of the outlet (:code:`15`) and
         the inlet cooling water stream (:code:`14`) represent the exergy losses
-        of the system (:code:`E_L`).
-
-        The product exergy (:code:`E_P`) is particulary complicated for this
-        model. There are two things you have to do in tespy:
-
-        a. Add components that generate or consume heat, which is transferred
-           over the system boundaries and therefore required for the analysis
-           to a :code:`Bus`. The :code:`base` keyword should be
-
-           - :code:`"bus"`, in case the component gains energy and
-           - :code:`"component"` in case it produces energy.
-
-        b. Then, you can use the following label:
-
-          - :code:`generator_of_<COMPONENT-LABEL>__<BUS-LABEL>` for the output
-            from a component to outside the system factoring in the specified
-            bus efficiency, and
-          - :code:`<BUS-LABEL>__motor_of_<COMPONENT-LABEL>` for the input from
-            outside of the system to a component inside also factoring in the
-            specified bus efficiency.
-
-        .. attention::
-
-            This is a drop-in adjustment of the tespy export structure to make
-            tespy compatible to the exerpy API. Expect, that the API will be
-            more SIMPLE in a future release of tespy.
+        of the system (:code:`E_L`). The product exergy (:code:`E_P`) is the
+        sum of the electrical energy :code:`E_TOT` and the exergy of the heat
+        :code:`H1`.
 
         .. literalinclude:: /../examples/ccpp/ccpp_tespy.py
             :language: python
@@ -222,7 +199,7 @@ The import of the exerpy dependency is the same for all simulators:
         .. note::
             At the moment, it is not possible to split the physical exergy into its mechanical and thermal shares
             when using Aspen Plus. Therefore, the :code:`split_physical_exergy` parameter should be always set to :code:`False`
-            when using the :code:`from_aspen` method.        
+            when using the :code:`from_aspen` method.
 
         .. code-block:: python
 

--- a/docs/examples/cgam.rst
+++ b/docs/examples/cgam.rst
@@ -171,31 +171,9 @@ The import of the exerpy dependency is the same for all simulators:
         inputs to the combustion process. The exhaust stream (:code:`7`)
         represents the exergy losses of the system (:code:`E_L`). The product
         exergy (:code:`E_P`) is the power output of the turbine minus the power
-        requirement of the compressor. As these are non-fluid streams of energy
-        the definition differes from the simple definition of the other two
-        parts in this case:
-
-        a. Add components that generate or consume heat, which is transferred
-           over the system boundaries and therefore required for the analysis
-           to a :code:`Bus`. The :code:`base` keyword should be
-
-           - :code:`"bus"`, in case the component gains energy and
-           - :code:`"component"` in case it produces energy.
-
-        b. Then, you can use the following label:
-
-          - :code:`generator_of_<COMPONENT-LABEL>__<BUS-LABEL>` for the output
-            from a component to outside the system factoring in the specified
-            bus efficiency, and
-          - :code:`<BUS-LABEL>__motor_of_<COMPONENT-LABEL>` for the input from
-            outside of the system to a component inside also factoring in the
-            specified bus efficiency.
-
-        .. attention::
-
-            This is a drop-in adjustment of the tespy export structure to make
-            tespy compatible to the exerpy API. Expect, that the API will be
-            more SIMPLE in a future release of tespy.
+        requirement of the compressor :code:`e3` as well as the difference in
+        total exergy between the flow of water entering the economizer
+        :code:`8`and the saturated steam leaving the drum :code:`9`.
 
         .. literalinclude:: /../examples/cgam/cgam_tespy.py
             :language: python

--- a/docs/examples/heatpump.rst
+++ b/docs/examples/heatpump.rst
@@ -165,31 +165,6 @@ The import of the exerpy dependency is the same for all simulators:
         loss of the system (:code:`E_L`), and the change of exergy from the
         liquid water to steam is considered the exergy product (:code:`E_P`).
 
-        For the fuel exergy (:code:`E_F`) the same structure applies as in the
-        other two examples, when implementing the tespy model:
-
-        a. Add components that generate or consume power or heat, which is
-           transferred over the system boundaries and therefore required for
-           the analysis to a :code:`Bus`. The :code:`base` keyword should be
-
-           - :code:`"bus"`, in case the component gains energy and
-           - :code:`"component"` in case it produces energy.
-
-        b. Then, you can use the following label:
-
-          - :code:`generator_of_<COMPONENT-LABEL>__<BUS-LABEL>` for the output
-            from a component to outside the system factoring in the specified
-            bus efficiency, and
-          - :code:`<BUS-LABEL>__motor_of_<COMPONENT-LABEL>` for the input from
-            outside of the system to a component inside also factoring in the
-            specified bus efficiency.
-
-        .. attention::
-
-            This is a drop-in adjustment of the tespy export structure to make
-            tespy compatible to the exerpy API. Expect, that the API will be
-            more SIMPLE in a future release of tespy.
-
         .. literalinclude:: /../examples/heatpump/hp_tespy.py
             :language: python
             :start-after: [exergy_analysis_setup]

--- a/docs/examples/json.rst
+++ b/docs/examples/json.rst
@@ -4,9 +4,13 @@
 Custom JSON Example
 *******************
 
-ExerPy can analyze data from simulation software that isn't directly supported (like Ebsilon Professional, Aspen Plus, or TESPy). This guide explains how to structure your data in a JSON file and use ExerPy's API to perform exergy analysis with external simulation data.
+ExerPy can analyze data from simulation software that isn't directly supported
+(like Ebsilon Professional, Aspen Plus, or TESPy). This guide explains how to
+structure your data in a JSON file and use ExerPy's API to perform exergy
+analysis with external simulation data.
 
-ExerPy requires specific data formatting in a JSON file. This is the required format:
+ExerPy requires specific data formatting in a JSON file. This is the required
+format:
 
 .. code-block:: json
 
@@ -20,7 +24,7 @@ ExerPy requires specific data formatting in a JSON file. This is the required fo
                 },
                 "ComponentClass2": {
                     "name": "CompName2",
-                    "parameter1": 100000,   
+                    "parameter1": 100000,
                     "parameter2": 0.98,
                 }
             },
@@ -84,20 +88,33 @@ ExerPy requires specific data formatting in a JSON file. This is the required fo
 
 Please ensure the following things:
 
-- The components should be grouped by their class (e.g., CombustionChamber, Compressor, Turbine, etc.)
-- Each component and each connection should have a unique name. 
-- The connections must specify the source and target components and their respective connectors. Visit the dedicated `ExerPy documentation <file:///Z:/Desktop/exerpy/docs/_build/api/components.html>`_ for more details on the connectors of each component.
-- If you want to split the physical exergy into thermal and mechanical parts, set :code:`"split_physical_exergy": true` in the Python code and make sure that the connections contain the :code:`e_M` and :code:`e_T` parameters. These values are not calculated by ExerPy, but must be provided in the JSON file!
-- If you want to use the chemical exergy library of Ahrendts, set :code:`"chemExLib": "Ahrendts"` in the Python code.
-- Ambient conditions (:code:`Tamb` and :code:`pamb`) must be provided in the JSON file.
-- The units for all parameters should be SI units (K, bar, kg/s, kW) for consistency.
+- The components should be grouped by their class (e.g., CombustionChamber,
+  Compressor, Turbine, etc.)
+- Each component and each connection should have a unique name.
+- The connections must specify the source and target components and their
+  respective connectors. Visit the dedicated
+  `ExerPy documentation <https://exerpy.readthedocs.io/en/latest/api/components.html>`__
+  for more details on the connectors of each component.
+- If you want to split the physical exergy into thermal and mechanical parts,
+  set :code:`"split_physical_exergy": true` in the Python code and make sure
+  that the connections contain the :code:`e_M` and :code:`e_T` parameters.
+  These values are not calculated by ExerPy, but must be provided in the JSON
+  file!
+- If you want to use the chemical exergy library of Ahrendts, set
+  :code:`"chemExLib": "Ahrendts"` in the Python code.
+- Ambient conditions (:code:`Tamb` and :code:`pamb`) must be provided in the
+  JSON file.
+- The units for all parameters should be SI units (K, bar, kg/s, kW) for
+  consistency.
 
 
 
 Example
 =======
 
-This is an example of how to perform an exergy analysis using ExerPy with a custom JSON file. The example is based on a simple gas turbine cycle with a combustion chamber, compressor, and generator.
+This is an example of how to perform an exergy analysis using ExerPy with a
+custom JSON file. The example is based on a simple gas turbine cycle with a
+combustion chamber, compressor, and generator.
 
 JSON file:
 


### PR DESCRIPTION
- Remove the outdated information on the tespy Bus usage
- Fix formatting and a broken link in the json example