### PR TITLE
Handle fluid vectors with entries that are equal to 0

### DIFF
--- a/src/exerpy/functions.py
+++ b/src/exerpy/functions.py
@@ -135,6 +135,11 @@ def calc_chemical_exergy(stream_data, Tamb, pamb, chemExLib):
         aliases_water = CP.get_aliases("H2O")
 
         # Handle pure substance (Case A)
+        molar_fractions = {
+            key: value
+            for key, value in molar_fractions.items()
+            if value > 1e-6
+        }
         if len(molar_fractions) == 1:
             logging.info("Handling pure substance case (Case A).")
             substance = next(iter(molar_fractions))  # Get the single key


### PR DESCRIPTION
We might want to change the threshold of 1e-6 to something lower, but there should be one to prevent numerical issues